### PR TITLE
Add fog of war player view to the core

### DIFF
--- a/Source/Simulturn.Core/Model/State/FogOfWar.cs
+++ b/Source/Simulturn.Core/Model/State/FogOfWar.cs
@@ -1,0 +1,94 @@
+namespace Simulturn.Core.Model.State;
+
+/// <summary>
+/// Computes what each player is allowed to know about the game.
+/// </summary>
+public static class FogOfWar
+{
+    /// <summary>
+    /// The minimum visibility required to observe static information (remaining matter, buildings) on a hexagon.
+    /// </summary>
+    public const Visibility StaticObservationThreshold = Visibility.PartiallyVisible;
+
+    /// <summary>
+    /// The minimum visibility required to observe opponent units on a hexagon.
+    /// </summary>
+    public const Visibility UnitObservationThreshold = Visibility.Visible;
+
+    /// <summary>
+    /// Updates the <see cref="PlayerState.Memories"/> of all players with a snapshot of every hexagon
+    /// that is at least partially visible to them on the given turn.
+    /// </summary>
+    public static ImmutableDictionary<string, PlayerState> UpdateMemories(ImmutableDictionary<string, PlayerState> playerStates,
+        ImmutableDictionary<Hexagon, int> remainingMatter,
+        ushort turn)
+    {
+        return playerStates.ToImmutableDictionary(x => x.Key, x =>
+        {
+            var memories = x.Value.Memories.ToBuilder();
+            foreach ((Hexagon hexagon, Visibility visibility) in x.Value.Visibilities)
+            {
+                if (visibility < StaticObservationThreshold)
+                {
+                    continue;
+                }
+                var opponentCompounds = playerStates
+                    .Where(y => y.Key != x.Key &&
+                        y.Value.Compounds.TryGetValue(hexagon, out var compound) &&
+                        !compound.IsEmpty)
+                    .ToImmutableDictionary(y => y.Key, y => y.Value.Compounds[hexagon]);
+                memories[hexagon] = new HexagonMemory()
+                {
+                    LastSeenTurn = turn,
+                    RemainingMatter = remainingMatter.GetValueOrDefault(hexagon),
+                    OpponentCompounds = opponentCompounds
+                };
+            }
+            return x.Value with { Memories = memories.ToImmutableDictionary() };
+        });
+    }
+
+    /// <summary>
+    /// Builds the partially informed view of the game for a single player.
+    /// </summary>
+    public static PlayerGameState GetPlayerGameState(GameState gameState, string playerId)
+    {
+        if (!gameState.PlayerStates.TryGetValue(playerId, out var playerState))
+        {
+            throw new ArgumentException($"Unknown player id '{playerId}'.", nameof(playerId));
+        }
+        var observations = ImmutableDictionary.CreateBuilder<Hexagon, HexagonObservation>();
+        foreach (Hexagon hexagon in gameState.Hexagons)
+        {
+            Visibility visibility = playerState.Visibilities.GetValueOrDefault(hexagon, Visibility.Unknown);
+            HexagonMemory? memory = playerState.Memories.GetValueOrDefault(hexagon);
+            var opponentUnitCounts = ImmutableDictionary<string, int>.Empty;
+            if (visibility >= UnitObservationThreshold)
+            {
+                opponentUnitCounts = gameState.PlayerStates
+                    .Where(x => x.Key != playerId &&
+                        x.Value.Armies.TryGetValue(hexagon, out var army) &&
+                        !army.IsEmpty)
+                    .ToImmutableDictionary(x => x.Key, x => x.Value.Armies[hexagon].Total);
+            }
+            observations[hexagon] = new HexagonObservation()
+            {
+                Visibility = visibility,
+                LastSeenTurn = memory?.LastSeenTurn,
+                RemainingMatter = memory?.RemainingMatter,
+                OpponentCompounds = memory?.OpponentCompounds ?? ImmutableDictionary<string, Compound>.Empty,
+                OpponentUnitCounts = opponentUnitCounts
+            };
+        }
+        return new PlayerGameState()
+        {
+            PlayerId = playerId,
+            Turn = gameState.Turn,
+            GameSettings = gameState.GameSettings,
+            PlayerIds = gameState.PlayerIds.ToImmutableHashSet(),
+            PlayerState = playerState,
+            Observations = observations.ToImmutableDictionary(),
+            IsGameOver = gameState.IsGameOver
+        };
+    }
+}

--- a/Source/Simulturn.Core/Model/State/GameState.cs
+++ b/Source/Simulturn.Core/Model/State/GameState.cs
@@ -46,6 +46,7 @@ public record GameState
                         : ImmutableDictionary<Upgrade, byte>.Empty
                 };
             });
+        PlayerStates = FogOfWar.UpdateMemories(PlayerStates, RemainingMatter, Turn);
         PlayerIds = PlayerStates.Keys.ToHashSet();
     }
 
@@ -308,10 +309,23 @@ public record GameState
         {
             throw new InvalidOperationException("Max turn limit reached.");
         }
+        ushort nextTurn = (ushort)(1 + Turn);
+        var newRemainingMatter = remainingMatter.ToImmutableDictionary();
+        var newPlayerStates = playerStates.ToImmutableDictionary(x => x.Key, x => x.Value.ToPlayerState(GameSettings));
+        newPlayerStates = FogOfWar.UpdateMemories(newPlayerStates, newRemainingMatter, nextTurn);
         return new GameState(GameSettings,
-            (ushort)(1 + Turn),
-            playerStates.ToImmutableDictionary(x => x.Key, x => x.Value.ToPlayerState(GameSettings)),
-            remainingMatter.ToImmutableDictionary());
+            nextTurn,
+            newPlayerStates,
+            newRemainingMatter);
+    }
+
+    /// <summary>
+    /// Builds the partially informed view of the game for a single player.
+    /// Clients and AI players must only receive this view, never the full game state.
+    /// </summary>
+    public PlayerGameState GetPlayerGameState(string playerId)
+    {
+        return FogOfWar.GetPlayerGameState(this, playerId);
     }
 
     private (Army lossesPlayer0, Army lossesPlayer1) Fight(string player1Id, Army army1, string player2Id, Army army2)

--- a/Source/Simulturn.Core/Model/State/HexagonMemory.cs
+++ b/Source/Simulturn.Core/Model/State/HexagonMemory.cs
@@ -1,0 +1,24 @@
+namespace Simulturn.Core.Model.State;
+
+/// <summary>
+/// What a player remembers about a hexagon from the last turn it was at least partially visible.
+/// The values are a snapshot and can be outdated if the hexagon is no longer visible.
+/// </summary>
+public record HexagonMemory
+{
+    /// <summary>
+    /// The turn on which the hexagon was last at least partially visible.
+    /// </summary>
+    public required ushort LastSeenTurn { get; init; }
+
+    /// <summary>
+    /// The remaining harvestable matter on the hexagon as of <see cref="LastSeenTurn"/>.
+    /// </summary>
+    public required int RemainingMatter { get; init; }
+
+    /// <summary>
+    /// The buildings of other players on the hexagon as of <see cref="LastSeenTurn"/>, keyed by player id.
+    /// Only contains players with at least one building on the hexagon.
+    /// </summary>
+    public required ImmutableDictionary<string, Compound> OpponentCompounds { get; init; }
+}

--- a/Source/Simulturn.Core/Model/State/HexagonObservation.cs
+++ b/Source/Simulturn.Core/Model/State/HexagonObservation.cs
@@ -1,0 +1,36 @@
+namespace Simulturn.Core.Model.State;
+
+/// <summary>
+/// Everything a player knows about a single hexagon.
+/// Static information (terrain, initial matter) is available through the game settings and not repeated here.
+/// </summary>
+public record HexagonObservation
+{
+    /// <summary>
+    /// The current visibility of the hexagon for the player.
+    /// </summary>
+    public required Visibility Visibility { get; init; }
+
+    /// <summary>
+    /// The turn on which the hexagon was last at least partially visible, or null if it was never seen.
+    /// Equals the current turn while the hexagon is at least partially visible.
+    /// </summary>
+    public ushort? LastSeenTurn { get; init; }
+
+    /// <summary>
+    /// The remaining harvestable matter as of <see cref="LastSeenTurn"/>, or null if the hexagon was never seen.
+    /// </summary>
+    public int? RemainingMatter { get; init; }
+
+    /// <summary>
+    /// The buildings of other players as of <see cref="LastSeenTurn"/>, keyed by player id.
+    /// Can be outdated if the hexagon is no longer visible.
+    /// </summary>
+    public ImmutableDictionary<string, Compound> OpponentCompounds { get; init; } = ImmutableDictionary<string, Compound>.Empty;
+
+    /// <summary>
+    /// The total number of units of other players currently on the hexagon, keyed by player id.
+    /// Only populated while the hexagon is fully visible. The unit composition remains hidden.
+    /// </summary>
+    public ImmutableDictionary<string, int> OpponentUnitCounts { get; init; } = ImmutableDictionary<string, int>.Empty;
+}

--- a/Source/Simulturn.Core/Model/State/PlayerGameState.cs
+++ b/Source/Simulturn.Core/Model/State/PlayerGameState.cs
@@ -1,0 +1,29 @@
+namespace Simulturn.Core.Model.State;
+
+/// <summary>
+/// Everything a single player is allowed to know about the game.
+/// Clients and AI players must only receive this view, never the full <see cref="GameState"/>.
+/// </summary>
+public record PlayerGameState
+{
+    public required string PlayerId { get; init; }
+    public required ushort Turn { get; init; }
+    public required GameSettings GameSettings { get; init; }
+
+    /// <summary>
+    /// The ids of all players in the game, including the own player id.
+    /// </summary>
+    public required ImmutableHashSet<string> PlayerIds { get; init; }
+
+    /// <summary>
+    /// The full own state of the player, including visibilities and memories.
+    /// </summary>
+    public required PlayerState PlayerState { get; init; }
+
+    /// <summary>
+    /// The knowledge of the player about every hexagon of the map.
+    /// </summary>
+    public required ImmutableDictionary<Hexagon, HexagonObservation> Observations { get; init; }
+
+    public required bool IsGameOver { get; init; }
+}

--- a/Source/Simulturn.Core/Model/State/PlayerState.cs
+++ b/Source/Simulturn.Core/Model/State/PlayerState.cs
@@ -23,6 +23,12 @@ public record PlayerState
     /// </summary>
     public ImmutableDictionary<Upgrade, byte> UpgradeLevels { get; init; } = ImmutableDictionary<Upgrade, byte>.Empty;
 
+    /// <summary>
+    /// What the player remembers about each hexagon from the last turn it was at least partially visible.
+    /// Hexagons that were never seen have no entry.
+    /// </summary>
+    public ImmutableDictionary<Hexagon, HexagonMemory> Memories { get; init; } = ImmutableDictionary<Hexagon, HexagonMemory>.Empty;
+
     public Army ExponentBonusFromUpgrades(GameSettings gameSettings)
     {
         // TODO: Extend upgrade exponent bonuses to support all unit-specific upgrades.

--- a/Source/Simulturn.Core/Model/State/PlayerStateBuilder.cs
+++ b/Source/Simulturn.Core/Model/State/PlayerStateBuilder.cs
@@ -15,6 +15,11 @@ public class PlayerStateBuilder
     public required ImmutableDictionary<Upgrade, byte>.Builder UpgradeLevels { get; init; }
     public required ImmutableDictionary<Hexagon, Army>.Builder Losses { get; init; }
 
+    /// <summary>
+    /// Carried over unchanged; memories are updated by <see cref="FogOfWar.UpdateMemories"/> once all player states of a turn are resolved.
+    /// </summary>
+    public required ImmutableDictionary<Hexagon, HexagonMemory> Memories { get; init; }
+
     public PlayerState ToPlayerState(GameSettings gameSettings)
     {
         return new PlayerState()
@@ -38,7 +43,8 @@ public class PlayerStateBuilder
                 gameSettings.HexagonSettings.Keys,
                 gameSettings.PartialVisibilityRange,
                 gameSettings.VisibilityRange),
-            Losses = Losses.ToImmutableDictionary()
+            Losses = Losses.ToImmutableDictionary(),
+            Memories = Memories
         };
     }
 
@@ -100,7 +106,8 @@ public class PlayerStateBuilder
                 kvp => kvp.Key,
                 kvp => kvp.Value.ToBuilder()).ToBuilder(),
             UpgradeLevels = playerState.UpgradeLevels.ToBuilder(),
-            Losses = ImmutableDictionary<Hexagon, Army>.Empty.ToBuilder()
+            Losses = ImmutableDictionary<Hexagon, Army>.Empty.ToBuilder(),
+            Memories = playerState.Memories
         };
     }
 }

--- a/Test/Simulturn.Core.Test/State/PlayerGameStateTest.cs
+++ b/Test/Simulturn.Core.Test/State/PlayerGameStateTest.cs
@@ -1,0 +1,232 @@
+using Simulturn.Core.Extensions;
+using Simulturn.Core.Model;
+using Simulturn.Core.Model.Commands;
+using Simulturn.Core.Model.State;
+using Simulturn.Core.Model.Upgrades;
+using System.Collections.Immutable;
+
+namespace Simulturn.Core.Test.State;
+
+public class PlayerGameStateTest
+{
+    private static readonly Hexagon _player1Start = new Hexagon(-3, 0);
+    private static readonly Hexagon _player2Start = new Hexagon(3, 0);
+    private static readonly Dictionary<string, Dictionary<Hexagon, Command>> _noCommands = [];
+
+    /// <summary>
+    /// A map of 7 hexagons in a line from (-3,0) to (3,0).
+    /// The players start on the opposite ends, 6 hexagons apart, with 5 dots and a plane each.
+    /// With a visibility range of 1 and a partial visibility range of 2, the players cannot see each other initially.
+    /// </summary>
+    private static readonly GameSettings _gameSettings = new()
+    {
+        Armor = new Compound() { Axis = 10, Dome = 20, Cube = 20, Plane = 30, Pyramid = 20 },
+        ArmyCost = new Army() { Triangle = 200, Circle = 200, Square = 200, Dot = 75 },
+        CompoundCost = new Compound() { Axis = 150, Dome = 100, Cube = 150, Plane = 350, Pyramid = 150 },
+        ConstructionDuration = new Compound() { Axis = 2, Dome = 3, Cube = 3, Plane = 4, Pyramid = 3 },
+        FightExponent = new Army() { Triangle = 120, Circle = 120, Square = 120, Dot = 1 },
+        Income = new Army() { Triangle = 0, Circle = 0, Square = 0, Dot = 10 },
+        ProvidedSpace = new Compound() { Axis = 10, Dome = 0, Cube = 0, Plane = 10, Pyramid = 0 },
+        RequiredSpace = new Army() { Triangle = 3, Circle = 3, Square = 3, Dot = 1 },
+        Seed = 1,
+        StartMatter = 500,
+        PartialVisibilityRange = 2,
+        VisibilityRange = 1,
+        StructureDamage = new Army() { Triangle = 5, Circle = 5, Square = 5, Dot = 1 },
+        TrainingDuration = new Army() { Triangle = 2, Circle = 2, Square = 2, Dot = 1 },
+        StartUpgrades = ImmutableDictionary<string, ImmutableArray<Upgrade>>.Empty,
+        Upgrades = new IUpgrade[]
+            {
+                new DotUpgrade() { Cost = 150, Duration = 3, ExponentBonus = 20 },
+                new DotUpgrade() { Cost = 175, Duration = 4, ExponentBonus = 20 }
+            }.ToDictionary(),
+        HexagonSettings = Enumerable.Range(-3, 7)
+            .ToImmutableDictionary(
+                x => new Hexagon((short)x, 0),
+                x => new HexagonSettings()
+                {
+                    IsBuildable = true,
+                    Matter = 1000,
+                    MaxNumberOfUnitsGeneratingMatter = new Army() { Dot = 12 },
+                    PlayerInitialization = x switch
+                    {
+                        -3 => ("Player01", new Army() { Dot = 5 }, new Compound() { Plane = 1 }),
+                        3 => ("Player02", new Army() { Dot = 5 }, new Compound() { Plane = 1 }),
+                        _ => ((string, Army, Compound)?)null
+                    }
+                })
+    };
+
+    private static GameState GetNextTurnAndValidate(GameState gameState, Dictionary<string, Dictionary<Hexagon, Command>> commands)
+    {
+        foreach ((string playerId, Dictionary<Hexagon, Command> playerCommands) in commands)
+        {
+            gameState.Validate(playerId, playerCommands).ShouldBeEmpty();
+        }
+        var newState = gameState.NextTurn(commands);
+        newState.IsValid().ShouldBeEmpty();
+        return newState;
+    }
+
+    private static Dictionary<string, Dictionary<Hexagon, Command>> Move(string playerId, Hexagon from, Hexagon to, Army army)
+    {
+        return DictionaryExtensions.MovementsToDictionary([(playerId, from, to, army)]);
+    }
+
+    /// <summary>
+    /// Places the second player on the given hexagon instead of its default start.
+    /// </summary>
+    private static GameSettings WithPlayer2At(Hexagon hexagon)
+    {
+        var builder = _gameSettings.HexagonSettings.ToBuilder();
+        builder[_player2Start] = builder[_player2Start] with { PlayerInitialization = null };
+        builder[hexagon] = builder[hexagon] with
+        {
+            PlayerInitialization = ("Player02", new Army() { Dot = 5 }, new Compound() { Plane = 1 })
+        };
+        return _gameSettings with { HexagonSettings = builder.ToImmutableDictionary() };
+    }
+
+    [Test]
+    public void InitialView_ContainsOwnSurroundingsAndHidesDistantHexagons()
+    {
+        var gameState = new GameState(_gameSettings);
+        var view = gameState.GetPlayerGameState("Player01");
+
+        view.PlayerId.ShouldBe("Player01");
+        view.Turn.ShouldBe((ushort)0);
+        view.IsGameOver.ShouldBeFalse();
+        view.PlayerIds.ShouldBe(["Player01", "Player02"], ignoreOrder: true);
+        view.PlayerState.Matter.ShouldBe(500);
+        view.Observations.Count.ShouldBe(7);
+
+        // Own start hexagon is occupied and fully known.
+        view.Observations[_player1Start].Visibility.ShouldBe(Visibility.Occupied);
+        view.Observations[_player1Start].LastSeenTurn.ShouldBe((ushort)0);
+        view.Observations[_player1Start].RemainingMatter.ShouldBe(1000);
+
+        // The adjacent hexagon is visible, the one behind partially visible.
+        view.Observations[new Hexagon(-2, 0)].Visibility.ShouldBe(Visibility.Visible);
+        view.Observations[new Hexagon(-1, 0)].Visibility.ShouldBe(Visibility.PartiallyVisible);
+        view.Observations[new Hexagon(-1, 0)].RemainingMatter.ShouldBe(1000);
+
+        // The opponent start hexagon is out of sight: no matter, no buildings, no units.
+        var enemyStart = view.Observations[_player2Start];
+        enemyStart.Visibility.ShouldBe(Visibility.Mapped);
+        enemyStart.LastSeenTurn.ShouldBeNull();
+        enemyStart.RemainingMatter.ShouldBeNull();
+        enemyStart.OpponentCompounds.ShouldBeEmpty();
+        enemyStart.OpponentUnitCounts.ShouldBeEmpty();
+
+        // No opponent information leaks anywhere on the map.
+        view.Observations.Values.ShouldAllBe(x => x.OpponentCompounds.IsEmpty && x.OpponentUnitCounts.IsEmpty);
+    }
+
+    [Test]
+    public void PartialVisibility_RevealsBuildingsAndMatterButNoUnits()
+    {
+        var gameSettings = WithPlayer2At(new Hexagon(-1, 0));
+        var gameState = new GameState(gameSettings);
+        var view = gameState.GetPlayerGameState("Player01");
+
+        var observation = view.Observations[new Hexagon(-1, 0)];
+        observation.Visibility.ShouldBe(Visibility.PartiallyVisible);
+        observation.RemainingMatter.ShouldBe(1000);
+        observation.OpponentCompounds.ShouldHaveSingleItem();
+        observation.OpponentCompounds["Player02"].ShouldBe(new Compound() { Plane = 1 });
+        observation.OpponentUnitCounts.ShouldBeEmpty();
+    }
+
+    [Test]
+    public void FullVisibility_RevealsUnitCount()
+    {
+        var gameSettings = WithPlayer2At(new Hexagon(-2, 0));
+        var gameState = new GameState(gameSettings);
+        var view = gameState.GetPlayerGameState("Player01");
+
+        var observation = view.Observations[new Hexagon(-2, 0)];
+        observation.Visibility.ShouldBe(Visibility.Visible);
+        observation.OpponentCompounds["Player02"].ShouldBe(new Compound() { Plane = 1 });
+        observation.OpponentUnitCounts.ShouldHaveSingleItem();
+        observation.OpponentUnitCounts["Player02"].ShouldBe(5);
+    }
+
+    [Test]
+    public void Memory_UpdatesWhileVisible()
+    {
+        var gameState = new GameState(_gameSettings);
+        var turn1 = GetNextTurnAndValidate(gameState, _noCommands);
+        var view = turn1.GetPlayerGameState("Player01");
+
+        // 5 dots harvested 50 matter on the own hexagon.
+        view.Observations[_player1Start].RemainingMatter.ShouldBe(1000 - 50);
+        view.Observations[_player1Start].LastSeenTurn.ShouldBe((ushort)1);
+    }
+
+    [Test]
+    public void Scouting_MemoryPersistsAndGetsStaleAfterLosingVision()
+    {
+        var gameState = new GameState(_gameSettings);
+        var scout = new Army() { Dot = 1 };
+
+        // Move a single dot from (-3,0) towards the opponent, one hexagon per turn.
+        var turn1 = GetNextTurnAndValidate(gameState, Move("Player01", new Hexagon(-3, 0), new Hexagon(-2, 0), scout));
+        var turn2 = GetNextTurnAndValidate(turn1, Move("Player01", new Hexagon(-2, 0), new Hexagon(-1, 0), scout));
+        var turn3 = GetNextTurnAndValidate(turn2, Move("Player01", new Hexagon(-1, 0), new Hexagon(0, 0), scout));
+        var turn4 = GetNextTurnAndValidate(turn3, Move("Player01", new Hexagon(0, 0), new Hexagon(1, 0), scout));
+
+        // From (1,0) the opponent start hexagon is partially visible: buildings and matter, but no units.
+        var view = turn4.GetPlayerGameState("Player01");
+        var observation = view.Observations[_player2Start];
+        observation.Visibility.ShouldBe(Visibility.PartiallyVisible);
+        observation.LastSeenTurn.ShouldBe((ushort)4);
+        observation.RemainingMatter.ShouldBe(1000 - 4 * 50); // 5 dots harvested 50 matter per turn
+        observation.OpponentCompounds["Player02"].ShouldBe(new Compound() { Plane = 1 });
+        observation.OpponentUnitCounts.ShouldBeEmpty();
+
+        // Retreat: the opponent start hexagon is out of sight again, the memory keeps the stale snapshot.
+        var turn5 = GetNextTurnAndValidate(turn4, Move("Player01", new Hexagon(1, 0), new Hexagon(0, 0), scout));
+        view = turn5.GetPlayerGameState("Player01");
+        observation = view.Observations[_player2Start];
+        observation.Visibility.ShouldBe(Visibility.Mapped);
+        observation.LastSeenTurn.ShouldBe((ushort)4);
+        observation.RemainingMatter.ShouldBe(800); // stale: the actual value is 750
+        observation.OpponentCompounds["Player02"].ShouldBe(new Compound() { Plane = 1 });
+
+        // The opponent constructs an axis while unseen; the memory must not change.
+        var constructAxis = DictionaryExtensions.CommandsToDictionary([
+            ("Player02", _player2Start, new Command() { Construction = new Compound() { Axis = 1 } })
+        ]);
+        var turn6 = GetNextTurnAndValidate(turn5, constructAxis);
+        var turn7 = GetNextTurnAndValidate(turn6, _noCommands); // axis completes
+        turn7.PlayerStates["Player02"].Compounds[_player2Start].ShouldBe(new Compound() { Plane = 1, Axis = 1 });
+        view = turn7.GetPlayerGameState("Player01");
+        observation = view.Observations[_player2Start];
+        observation.LastSeenTurn.ShouldBe((ushort)4);
+        observation.OpponentCompounds["Player02"].ShouldBe(new Compound() { Plane = 1 });
+
+        // Scout again: the memory updates to the new buildings.
+        var turn8 = GetNextTurnAndValidate(turn7, Move("Player01", new Hexagon(0, 0), new Hexagon(1, 0), scout));
+        view = turn8.GetPlayerGameState("Player01");
+        observation = view.Observations[_player2Start];
+        observation.Visibility.ShouldBe(Visibility.PartiallyVisible);
+        observation.LastSeenTurn.ShouldBe((ushort)8);
+        observation.OpponentCompounds["Player02"].ShouldBe(new Compound() { Plane = 1, Axis = 1 });
+        observation.OpponentUnitCounts.ShouldBeEmpty();
+
+        // Move next to the opponent: full visibility reveals the unit count.
+        var turn9 = GetNextTurnAndValidate(turn8, Move("Player01", new Hexagon(1, 0), new Hexagon(2, 0), scout));
+        view = turn9.GetPlayerGameState("Player01");
+        observation = view.Observations[_player2Start];
+        observation.Visibility.ShouldBe(Visibility.Visible);
+        observation.OpponentUnitCounts["Player02"].ShouldBe(5);
+    }
+
+    [Test]
+    public void GetPlayerGameState_ThrowsForUnknownPlayer()
+    {
+        var gameState = new GameState(_gameSettings);
+
+        Should.Throw<ArgumentException>(() => gameState.GetPlayerGameState("UnknownPlayer"));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds per-hexagon **memories** to `PlayerState`: whenever a hexagon is at least partially visible, the player stores a snapshot (last-seen turn, remaining matter, opponent buildings). Memories persist when vision is lost, so knowledge goes stale instead of vanishing.
- Adds `PlayerGameState` — the partially informed view of the game for a single player, built via `GameState.GetPlayerGameState(playerId)`. Clients (web app, future AI players) receive only this view, never the full `GameState`.
- Visibility rules per hexagon (following the README visibility table):
  - Static info (terrain, initial matter) is always known via the game settings
  - Remaining matter and enemy buildings require at least partial visibility; values can be stale after losing vision
  - Enemy unit **counts** require full visibility
  - Enemy unit **composition** stays hidden (reserved for the future infiltration mechanic)

## Test plan
- [x] 6 new tests in `PlayerGameStateTest`, incl. an end-to-end scouting scenario (scout out → memorize enemy base → retreat → memory goes stale while the enemy secretly builds → re-scout refreshes)
- [x] All 22 tests pass, existing 16 unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)